### PR TITLE
Package's previous version status validation

### DIFF
--- a/qubership-apihub-service/exception/ErrorCodes.go
+++ b/qubership-apihub-service/exception/ErrorCodes.go
@@ -108,6 +108,9 @@ const IncorrectFileNameMsg = "File name is incorrect: '$name'"
 const FileByRefNotFound = "47"
 const FileByRefNotFoundMsg = "File for path $fileId not found by reference $ref in project $projectGitId"
 
+const PreviousPackageVersionNotRelease = "48"
+const PreviousPackageVersionNotReleaseMsg = "Previous version $version for package $packageId is not in the 'release' status"
+
 const PublishedPackageVersionNotFound = "49"
 const PublishedPackageVersionNotFoundMsg = "Published version $version not found for package $packageId"
 

--- a/qubership-apihub-service/service/VersionService.go
+++ b/qubership-apihub-service/service/VersionService.go
@@ -2078,6 +2078,14 @@ func (v versionServiceImpl) StartPublishFromCSV(ctx context.SecurityContext, req
 				Params:  map[string]interface{}{"packageId": previousVersionPackageId, "version": req.PreviousVersion},
 			}
 		}
+		if prevVersion.Status != string(view.Release) {
+			return "", &exception.CustomError{
+				Status:  http.StatusNotFound,
+				Code:    exception.PreviousPackageVersionNotRelease,
+				Message: exception.PreviousPackageVersionNotReleaseMsg,
+				Params:  map[string]interface{}{"packageId": previousVersionPackageId, "version": req.PreviousVersion},
+			}
+		}
 	}
 
 	publishEntity := &entity.CSVDashboardPublishEntity{


### PR DESCRIPTION
Shall fix issue #4 
Validates that package's previous version is in the 'release' status. Breaks with error if not.