### PR TITLE
added "linterEnabled" property 

### DIFF
--- a/docs/api/APIHUB API.yaml
+++ b/docs/api/APIHUB API.yaml
@@ -2767,7 +2767,7 @@ components:
           description: Production environment flag
           type: boolean
         linterEnabled:
-          description: Linter service availability flag
+          description: qubership-api-linter-service availability flag
           type: boolean
         externalLinks:
           description: List of links to the external resource, for example URL to the documentation or URL pointing to the contact information of support group.


### PR DESCRIPTION
added "linterEnabled" property which indicates whether the Linter microservice is enabled in the current deployment.
<!-- start messages -->
### Commit messages:
[zloiadil](https://github.com/Netcracker/qubership-apihub-backend/commit/3fbdee94733cfb16ddf52f73bfdd9e61c6d13d2b) added "linterEnabled" property to SystemInfo
[zloiadil](https://github.com/Netcracker/qubership-apihub-backend/commit/d3fcd1140b265ef32d93e884e8647fc2a92895e4) edited description in "linterEnabled" property
<!-- end messages -->
