### PR TITLE
Relevance of api-processor version

### DIFF
--- a/docs/api/APIHUB API.yaml
+++ b/docs/api/APIHUB API.yaml
@@ -1481,7 +1481,7 @@ paths:
     get:
       tags:
         - Custom
-      summary: Get system info"
+      summary: Get system info.
       description: Get system info.
       operationId: getInfo
       parameters: []
@@ -2774,6 +2774,13 @@ components:
               Title for the link and corresponding URL. Value must written in the following format <linkTitle>|<URL>. If array item does not contain vertical bar (|), then this item will be skipped.
             type: string
           example: [User guide|https://www.example.com/guide, Support team|https://www.example.com/support]
+        migrationInProgress:
+          description: Identifies if migration is currently in progress.
+          type: boolean
+          default: false
+        apiProcessorVerson:
+          description: Current version of api-processor on backend.
+          type: string
     ValidationParams:
       description: qubership product release custom API validation parameters
       properties:

--- a/docs/api/Public Registry API.yaml
+++ b/docs/api/Public Registry API.yaml
@@ -14246,6 +14246,9 @@ components:
         notLatestRevision:
           type: boolean
           default: false
+        apiProcessorVerson:
+          description: Version of api-processor with which current version was builded.
+          type: string
     PackageVersionContentV2:
       deprecated: true
       description: Published package version content
@@ -14311,6 +14314,7 @@ components:
         - revision
         - revisionsCount
         - status
+        - apiProcessorVerson
       properties:
         packageId:
           description: Package unique string identifier (full alias)
@@ -14350,6 +14354,9 @@ components:
           example: 3
         status:
           $ref: "#/components/schemas/VersionStatusEnum"
+        apiProcessorVerson:
+          description: Version of api-processor with which current version was builded.
+          type: string
     PackageVersionFile:
       description: Parameters of published file in package version
       type: object


### PR DESCRIPTION
1. Get info if migration is in progress
2. Get current api-processor version on backend
3. Get  api-processor version with which specific package version was builded