### PR TITLE
Search by customTags for list of operations from group should match key: value

### DIFF
--- a/qubership-apihub-service/repository/OperationRepository.go
+++ b/qubership-apihub-service/repository/OperationRepository.go
@@ -1682,14 +1682,14 @@ func (o operationRepositoryImpl) GetGroupedOperations(packageId string, version 
 		Offset(searchReq.Limit * searchReq.Page).
 		Limit(searchReq.Limit)
 
-	if searchReq.TextFilter != "" {
+	if searchReq.CustomTagKey != "" && searchReq.CustomTagValue != "" {
+		query.Where("exists(select 1 from jsonb_each_text(operation.custom_tags) where key = ? and value = ?)", searchReq.CustomTagKey, searchReq.CustomTagValue)
+	} else if searchReq.TextFilter != "" {
 		searchReq.TextFilter = "%" + utils.LikeEscaped(searchReq.TextFilter) + "%"
 		query.WhereGroup(func(q *pg.Query) (*pg.Query, error) {
 			q = q.WhereOr("operation.title ilike ?", searchReq.TextFilter).
 				WhereOr("operation.metadata->>? ilike ?", "path", searchReq.TextFilter).
-				WhereOr("operation.metadata->>? ilike ?", "method", searchReq.TextFilter).
-				WhereOr("exists(select 1 from jsonb_each_text(operation.custom_tags) where key ilike ? OR value ilike ?)",
-					searchReq.TextFilter, searchReq.TextFilter)
+				WhereOr("operation.metadata->>? ilike ?", "method", searchReq.TextFilter)
 			return q, nil
 		})
 	}

--- a/qubership-apihub-service/service/OperationGroupService.go
+++ b/qubership-apihub-service/service/OperationGroupService.go
@@ -878,6 +878,10 @@ func (o operationGroupServiceImpl) GetGroupedOperations(packageId string, versio
 	if searchReq.Kind == "all" {
 		searchReq.Kind = ""
 	}
+	searchReq.CustomTagKey, searchReq.CustomTagValue, err = parseTextFilterToCustomTagKeyValue(searchReq.TextFilter)
+	if err != nil {
+		return nil, err
+	}
 	operationEnts, err := o.operationRepo.GetGroupedOperations(versionEnt.PackageId, versionEnt.Version, versionEnt.Revision, apiType, groupName, searchReq)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION

<!-- start messages -->
### Commit messages:
[karpov-aleksandr](https://github.com/Netcracker/qubership-apihub-backend/commit/8045a33d75aad89f20b88cffdf19f6aa7a504f1d) Change search by customTags approach for grouped operations
<!-- end messages -->
