### PR TITLE
fix: change summary is not calculated when a previous version is published after it's latter version was already published

### DIFF
--- a/qubership-apihub-service/repository/PublishedRepositoryPG.go
+++ b/qubership-apihub-service/repository/PublishedRepositoryPG.go
@@ -1845,12 +1845,12 @@ func (p publishedRepositoryImpl) GetVersionsByPreviousVersion(previousPackageId 
                 on pv.package_id = mx.package_id
                 and pv.version = mx.version
                 and pv.revision = mx.revision
-			where pv.previous_version_package_id = ?
+			where (pv.previous_version_package_id = ? or pv.package_id = ?)
 			and pv.previous_version = ?
 			and pv.deleted_at is null
 			order by pv.published_at desc
  `
-	_, err = p.cp.GetConnection().Query(&ents, query, previousPackageId, previousVersion, previousPackageId, previousVersion)
+	_, err = p.cp.GetConnection().Query(&ents, query, previousPackageId, previousPackageId, previousVersion)
 	if err != nil {
 		if err == pg.ErrNoRows {
 			return nil, nil

--- a/qubership-apihub-service/repository/PublishedRepositoryPG.go
+++ b/qubership-apihub-service/repository/PublishedRepositoryPG.go
@@ -1845,7 +1845,7 @@ func (p publishedRepositoryImpl) GetVersionsByPreviousVersion(previousPackageId 
                 on pv.package_id = mx.package_id
                 and pv.version = mx.version
                 and pv.revision = mx.revision
-			where (pv.previous_version_package_id = ? or pv.package_id = ?)
+			where (pv.previous_version_package_id = ? or (pv.package_id = ? and pv.previous_version_package_id is null))
 			and pv.previous_version = ?
 			and pv.deleted_at is null
 			order by pv.published_at desc

--- a/qubership-apihub-service/service/PublishedService.go
+++ b/qubership-apihub-service/service/PublishedService.go
@@ -1267,8 +1267,8 @@ func (p publishedServiceImpl) reCalculateChangelogs(packageInfo view.PackageInfo
 	for _, version := range versions {
 		buildConfig = view.BuildConfig{
 			PackageId:                version.PackageId,
-			Version:                  version.Version,
-			PreviousVersion:          version.PreviousVersion,
+			Version:                  fmt.Sprintf("%v@%v", version.Version, version.Revision),
+			PreviousVersion:          fmt.Sprintf("%v@%v", packageInfo.Version, packageInfo.Revision),
 			PreviousVersionPackageId: version.PreviousVersionPackageId,
 			BuildType:                view.ChangelogType,
 			CreatedBy:                packageInfo.CreatedBy,
@@ -1300,6 +1300,9 @@ func (p publishedServiceImpl) PublishChanges(buildArc *archive.BuildResultArchiv
 	buildArc.PackageInfo.PreviousVersion, buildArc.PackageInfo.PreviousVersionRevision, err = SplitVersionRevision(buildArc.PackageInfo.PreviousVersion)
 	if err != nil {
 		return err
+	}
+	if buildArc.PackageInfo.PreviousVersionPackageId == "" {
+		buildArc.PackageInfo.PreviousVersionPackageId = buildArc.PackageInfo.PackageId
 	}
 	if err := p.publishedValidator.ValidateChanges(buildArc); err != nil {
 		return err

--- a/qubership-apihub-service/service/PublishedService.go
+++ b/qubership-apihub-service/service/PublishedService.go
@@ -1265,11 +1265,15 @@ func (p publishedServiceImpl) reCalculateChangelogs(packageInfo view.PackageInfo
 	}
 	var buildConfig view.BuildConfig
 	for _, version := range versions {
+		previousVersionPackageId := version.PreviousVersionPackageId
+		if previousVersionPackageId == "" {
+			previousVersionPackageId = version.PackageId
+		}
 		buildConfig = view.BuildConfig{
 			PackageId:                version.PackageId,
 			Version:                  fmt.Sprintf("%v@%v", version.Version, version.Revision),
 			PreviousVersion:          fmt.Sprintf("%v@%v", packageInfo.Version, packageInfo.Revision),
-			PreviousVersionPackageId: version.PreviousVersionPackageId,
+			PreviousVersionPackageId: previousVersionPackageId,
 			BuildType:                view.ChangelogType,
 			CreatedBy:                packageInfo.CreatedBy,
 			PublishedAt:              time.Now(),

--- a/qubership-apihub-service/service/PublishedService.go
+++ b/qubership-apihub-service/service/PublishedService.go
@@ -1305,9 +1305,6 @@ func (p publishedServiceImpl) PublishChanges(buildArc *archive.BuildResultArchiv
 	if err != nil {
 		return err
 	}
-	if buildArc.PackageInfo.PreviousVersionPackageId == "" {
-		buildArc.PackageInfo.PreviousVersionPackageId = buildArc.PackageInfo.PackageId
-	}
 	if err := p.publishedValidator.ValidateChanges(buildArc); err != nil {
 		return err
 	}


### PR DESCRIPTION
Commit messages:

[sujithn-nc](https://github.com/Netcracker/qubership-apihub-backend/commit/c52c8220c81bcb91bb220e0b3e17693739ee0c44) fix sql query, update build config and minor fix in publishChanges func for recalculateChangeLogs scenario