### PR TITLE
bug: add index for build.metadata->>migration_id and ->>build_type to…

### DIFF
--- a/qubership-apihub-service/resources/migrations/28_add_build_idx.down.sql
+++ b/qubership-apihub-service/resources/migrations/28_add_build_idx.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_build_migration_id_build_type;

--- a/qubership-apihub-service/resources/migrations/28_add_build_idx.up.sql
+++ b/qubership-apihub-service/resources/migrations/28_add_build_idx.up.sql
@@ -1,0 +1,6 @@
+CREATE INDEX IF NOT EXISTS idx_build_migration_id_build_type
+ON public.build
+(
+  (metadata->>'migration_id'),
+  (metadata->>'build_type')
+);


### PR DESCRIPTION
… fix slow migration if build table has many rows