### PR TITLE
fix: prevent MCP stream session memory growth

### DIFF
--- a/qubership-apihub-service/Service.go
+++ b/qubership-apihub-service/Service.go
@@ -689,8 +689,18 @@ func makeServer(systemInfoService service.SystemInfoService, r *mux.Router) *htt
 	//   - http.ResponseController.SetWriteDeadline per-request (see middleware/WriteDeadlineMiddleware.go) to set
 	//     a deadline only on the response writing phase, independent of processing time.
 	//   - Context with deadline for processing time control (planned, not yet implemented).
+	corsHandler := handlers.CORS(corsOptions...)(r)
+	compressedHandler := handlers.CompressHandler(corsHandler)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/api/v1/mcp/") {
+			corsHandler.ServeHTTP(w, r)
+			return
+		}
+		compressedHandler.ServeHTTP(w, r)
+	})
+
 	return &http.Server{
-		Handler:     handlers.CompressHandler(handlers.CORS(corsOptions...)(r)),
+		Handler:     handler,
 		Addr:        listenAddr,
 		ReadTimeout: 60 * time.Second,
 	}

--- a/qubership-apihub-service/controller/MCPController.go
+++ b/qubership-apihub-service/controller/MCPController.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"net/http"
+	"time"
 
 	apihubctx "github.com/Netcracker/qubership-apihub-backend/qubership-apihub-service/context"
 	"github.com/Netcracker/qubership-apihub-backend/qubership-apihub-service/service"
@@ -20,6 +21,7 @@ type mcpControllerImpl struct {
 func (m mcpControllerImpl) MakeMCPServer() http.Handler {
 	return mcpserver.NewStreamableHTTPServer(
 		m.mcpService.MakeMCPServer(),
+		mcpserver.WithSessionIdleTTL(30*time.Minute),
 		mcpserver.WithHTTPContextFunc(func(ctx context.Context, r *http.Request) context.Context {
 			secCtx := apihubctx.Create(r)
 			userID := secCtx.GetUserId()

--- a/qubership-apihub-service/controller/MCPController.go
+++ b/qubership-apihub-service/controller/MCPController.go
@@ -21,7 +21,7 @@ type mcpControllerImpl struct {
 func (m mcpControllerImpl) MakeMCPServer() http.Handler {
 	return mcpserver.NewStreamableHTTPServer(
 		m.mcpService.MakeMCPServer(),
-		mcpserver.WithSessionIdleTTL(30*time.Minute),
+		mcpserver.WithSessionIdleTTL(15*time.Minute),
 		mcpserver.WithHTTPContextFunc(func(ctx context.Context, r *http.Request) context.Context {
 			secCtx := apihubctx.Create(r)
 			userID := secCtx.GetUserId()

--- a/qubership-apihub-service/go.mod
+++ b/qubership-apihub-service/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/gosimple/slug v1.15.0
 	github.com/iancoleman/orderedmap v0.3.0
-	github.com/mark3labs/mcp-go v0.50.0
+	github.com/mark3labs/mcp-go v0.52.0
 	github.com/minio/minio-go/v7 v7.1.0
 	github.com/openai/openai-go/v3 v3.33.0
 	github.com/pkg/errors v0.9.1

--- a/qubership-apihub-service/middleware/WriteDeadlineMiddleware.go
+++ b/qubership-apihub-service/middleware/WriteDeadlineMiddleware.go
@@ -2,6 +2,7 @@ package midldleware
 
 import (
 	"net/http"
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -18,6 +19,7 @@ import (
 // The client receives whatever bytes were already transmitted, then sees a connection reset.
 // The server goroutine is freed when the handler returns.
 const responseWriteDeadline = 5 * time.Minute
+const mcpPathPrefix = "/api/v1/mcp/"
 
 type deadlineResponseWriter struct {
 	http.ResponseWriter
@@ -57,6 +59,12 @@ func (w *deadlineResponseWriter) Flush() {
 
 func WriteDeadlineMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// MCP uses long-lived streaming responses, so a fixed write deadline
+		// would terminate healthy streams and force clients to reconnect.
+		if strings.HasPrefix(r.URL.Path, mcpPathPrefix) {
+			next.ServeHTTP(w, r)
+			return
+		}
 		next.ServeHTTP(&deadlineResponseWriter{ResponseWriter: w}, r)
 	})
 }


### PR DESCRIPTION
Upgrade mcp-go to a version with streamable HTTP session cleanup and harden the MCP endpoint against long-lived SSE regressions.

Skip write deadlines and response compression for /api/v1/mcp/ so healthy MCP streams do not get cut off and force reconnect loops that accumulate server-side session state.