### PR TITLE
Normalize public contacts and examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Please, follow these guidelines to make the contribution process easy and effect
 
 ## Contributor License Agreement
 
-You must sign the [Contributor License Agreement](https://pages.netcracker.com/cla-main.html) in order to contribute.
+You must sign the [Contributor License Agreement](https://github.com/Netcracker/qubership-workflow-hub/blob/main/CLA/cla.md) in order to contribute.
 
 ## Code of Conduct
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,11 +1,13 @@
-# Security Reporting Process
+# Security Policy
+
+## Reporting a Vulnerability
 
 Please, report any security issue to `opensourcegroup@netcracker.com` where the issue will be triaged appropriately.
 
 If you know of a publicly disclosed security vulnerability please IMMEDIATELY email `opensourcegroup@netcracker.com`
 to inform the team about the vulnerability, so we may start the patch, release, and communication process.
 
-# Security Release Process
+## Security Release Process
 
 If the vulnerability is found in the latest stable release, then it would be fixed in patch version for that release.
 E.g., issue is found in 2.5.0 release, then 2.5.1 version with a fix will be released.

--- a/docs/api/APIHUB_API.yaml
+++ b/docs/api/APIHUB_API.yaml
@@ -4,8 +4,8 @@ info:
   description: |
     Public-facing API contract for APIHUB. This API is intended for external and integration clients and covers package/catalog operations, publication workflows, search, user/profile actions, and selected administration capabilities secured by APIHUB authentication schemes.
   contact:
-    name: Netcracker Opensource Group
-    email: opensourcegroup@netcracker.com
+    name: API Support
+    email: apisupport@netcracker.com
   license:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
@@ -571,7 +571,7 @@ paths:
                                 memberName:
                                   description: User which was added/deleted to/from package with some role(s)
                                   type: string
-                                  example: Name Surname
+                                  example: John Doe
                                 roles:
                                   type: array
                                   items:
@@ -590,7 +590,7 @@ paths:
                                 memberName:
                                   description: User which was added/deleted to/from package with some role(s)
                                   type: string
-                                  example: Name Surname
+                                  example: John Doe
                             - type: object
                               title: ParamsForPublishAndDeleteVersion
                               description: params for publish_new_version and delete_version events
@@ -1508,7 +1508,7 @@ paths:
                                 memberName:
                                   description: User which was added/deleted to/from package with some role(s)
                                   type: string
-                                  example: Name Surname
+                                  example: John Doe
                                 roles:
                                   type: array
                                   items:
@@ -1527,7 +1527,7 @@ paths:
                                 memberName:
                                   description: User which was added/deleted to/from package with some role(s)
                                   type: string
-                                  example: Name Surname
+                                  example: John Doe
                             - type: object
                               title: ParamsForPublishAndDeleteVersion
                               description: params for publish_new_version and delete_version events
@@ -11172,12 +11172,12 @@ components:
         name:
           description: Name of the user
           type: string
-          example: "Name Surname"
+          example: "John Doe"
         email:
           description: Email address of the user
           type: string
           format: email
-          example: "name.surname@qubership.org"
+          example: "john.doe@example.com"
         avatarUrl:
           description: URL of the user avatar image.
           type: string
@@ -11295,7 +11295,7 @@ components:
           items:
             type: string
             format: email
-          example: ["name.surname@qubership.org"]
+          example: ["john.doe@example.com"]
         roleIds:
           type: array
           description: List of role IDs, added to the user.

--- a/docs/api/APIHUB_API.yaml
+++ b/docs/api/APIHUB_API.yaml
@@ -4,8 +4,8 @@ info:
   description: |
     Public-facing API contract for APIHUB. This API is intended for external and integration clients and covers package/catalog operations, publication workflows, search, user/profile actions, and selected administration capabilities secured by APIHUB authentication schemes.
   contact:
-    name: API Support
-    email: apisupport@netcracker.com
+    name: Netcracker Opensource Group
+    email: opensourcegroup@netcracker.com
   license:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0

--- a/docs/api/APIHUB_API_internal.yaml
+++ b/docs/api/APIHUB_API_internal.yaml
@@ -4,8 +4,8 @@ info:
   description: |
     Internal-only API contract for APIHUB services. This API is intended for trusted internal components and administrators, and includes internal management, migration, integration, and maintenance operations.
   contact:
-    name: API Support
-    email: apisupport@netcracker.com
+    name: Netcracker Opensource Group
+    email: opensourcegroup@netcracker.com
   license:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0

--- a/docs/api/APIHUB_API_internal.yaml
+++ b/docs/api/APIHUB_API_internal.yaml
@@ -4,8 +4,8 @@ info:
   description: |
     Internal-only API contract for APIHUB services. This API is intended for trusted internal components and administrators, and includes internal management, migration, integration, and maintenance operations.
   contact:
-    name: Netcracker Opensource Group
-    email: opensourcegroup@netcracker.com
+    name: API Support
+    email: apisupport@netcracker.com
   license:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
@@ -859,11 +859,11 @@ paths:
                   description: Email address of the user
                   type: string
                   format: email
-                  example: "name.surname@qubership.org"
+                  example: "john.doe@example.com"
                 name:
                   description: Name of the user
                   type: string
-                  example: "Name Surname"
+                  example: "John Doe"
                 password:
                   type: string
                   description: User password.
@@ -1009,12 +1009,12 @@ components:
         name:
           description: Name of the user
           type: string
-          example: "Name Surname"
+          example: "John Doe"
         email:
           description: Email address of the user
           type: string
           format: email
-          example: "name.surname@qubership.org"
+          example: "john.doe@example.com"
         avatarUrl:
           description: URL of the user avatar image.
           type: string

--- a/docs/api/Admin API.yaml
+++ b/docs/api/Admin API.yaml
@@ -4,8 +4,8 @@ info:
   description: |
     External API contract for system administrators. This API covers technical administration operations such as package transitions, role management, administrator management, and selected operational actions. All endpoints require authenticated access and are intended for trusted administrative users.
   contact:
-    name: Netcracker Opensource Group
-    email: opensourcegroup@netcracker.com
+    name: API Support
+    email: apisupport@netcracker.com
   license:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
@@ -1092,12 +1092,12 @@ components:
         name:
           description: Name of the user
           type: string
-          example: "Name Surname"
+          example: "John Doe"
         email:
           description: Email address of the user
           type: string
           format: email
-          example: "name.surname@qubership.org"
+          example: "john.doe@example.com"
         avatarUrl:
           description: URL of the user avatar image.
           type: string

--- a/docs/api/Admin API.yaml
+++ b/docs/api/Admin API.yaml
@@ -4,8 +4,8 @@ info:
   description: |
     External API contract for system administrators. This API covers technical administration operations such as package transitions, role management, administrator management, and selected operational actions. All endpoints require authenticated access and are intended for trusted administrative users.
   contact:
-    name: API Support
-    email: apisupport@netcracker.com
+    name: Netcracker Opensource Group
+    email: opensourcegroup@netcracker.com
   license:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0

--- a/docs/api/Admin_API_internal.yaml
+++ b/docs/api/Admin_API_internal.yaml
@@ -4,8 +4,8 @@ info:
   description: |
     Internal-only API contract for system administrators. This API includes privileged technical administration endpoints for diagnostics, maintenance, and internal management operations.
   contact:
-    name: API Support
-    email: apisupport@netcracker.com
+    name: Netcracker Opensource Group
+    email: opensourcegroup@netcracker.com
   license:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0

--- a/docs/api/Admin_API_internal.yaml
+++ b/docs/api/Admin_API_internal.yaml
@@ -4,8 +4,8 @@ info:
   description: |
     Internal-only API contract for system administrators. This API includes privileged technical administration endpoints for diagnostics, maintenance, and internal management operations.
   contact:
-    name: Netcracker Opensource Group
-    email: opensourcegroup@netcracker.com
+    name: API Support
+    email: apisupport@netcracker.com
   license:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0

--- a/qubership-apihub-service/config/Config.go
+++ b/qubership-apihub-service/config/Config.go
@@ -169,7 +169,7 @@ type ChatConfig struct {
 type OpenAIConfig struct {
 	ApiKey          string `sensitive:"true"`
 	Model           string
-	ProxyURL        string  // Optional base URL for OpenAI API requests (replaces https://api.openai.com/v1); Example: "https://llmproxy.localdomain.com" or "https://llmproxy.localdomain.com/v1"
+	ProxyURL        string  // Optional base URL for OpenAI API requests (replaces https://api.openai.com/v1); Example: "https://llmproxy.example.com" or "https://llmproxy.example.com/v1"
 	Temperature     float64 // Controls randomness of the model's output. Range: 0.0 to 2.0. Lower values = more focused, higher values = more random. Default: 1.0
 	ReasoningEffort string  // Controls depth of reasoning for reasoning models (gpt-5, o-series). Values: "minimal", "low", "medium", "high". Default: "medium"
 	Verbosity       string  // Controls verbosity and detail level of the model's response. Values: "low", "medium", "high". Default: "medium"


### PR DESCRIPTION
## Summary

- Normalize public contact files and example email addresses.
- Keep API support and repository feedback contacts aligned with approved addresses.
- Replace personal-looking examples with neutral example data where applicable.

## Changed files

- CONTRIBUTING.md
- SECURITY.md
- docs/api/APIHUB_API.yaml
- docs/api/APIHUB_API_internal.yaml
- docs/api/Admin API.yaml
- docs/api/Admin_API_internal.yaml
- qubership-apihub-service/config/Config.go

## Commit

4e356da chore: normalize public contacts and examples
 CONTRIBUTING.md                           |  2 +-
 SECURITY.md                               |  6 ++++--
 docs/api/APIHUB_API.yaml                  | 18 +++++++++---------
 docs/api/APIHUB_API_internal.yaml         | 12 ++++++------
 docs/api/Admin API.yaml                   |  8 ++++----
 docs/api/Admin_API_internal.yaml          |  4 ++--
 qubership-apihub-service/config/Config.go |  2 +-
 7 files changed, 27 insertions(+), 25 deletions(-)
