### PR TITLE
feat: secure TLS for HTTP clients (supersedes #260)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Note: this uses host platform for the build, and we ask go build to target the needed platform, so we do not spend time on qemu emulation when running "go build"
-FROM --platform=$BUILDPLATFORM docker.io/golang:1.26.1-alpine3.23 as builder
+FROM --platform=$BUILDPLATFORM docker.io/golang:1.26.1-alpine3.23 AS builder
 ARG BUILDPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
@@ -12,7 +12,7 @@ WORKDIR /workspace/qubership-apihub-service
 
 RUN GOSUMDB=off CGO_ENABLED=0 go mod tidy && go mod download && GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build .
 
-FROM docker.io/alpine:3.23
+FROM ghcr.io/netcracker/qubership-core-base:2.3.3@sha256:1339716127a7d170ba307b89f3a933f5e09c447607c89e16bf8d5a379db4e1f6
 
 ARG GIT_BRANCH=unknown
 ARG GIT_HASH=unknown
@@ -22,18 +22,11 @@ ENV GIT_HASH=$GIT_HASH
 
 WORKDIR /app/qubership-apihub-service
 
-USER root
+COPY --chown=10001:0 --chmod=555 --from=builder /workspace/qubership-apihub-service/qubership-apihub-service ./qubership-apihub-service
+COPY --chown=10001:0 --chmod=444 qubership-apihub-service/static ./static
+COPY --chown=10001:0 --chmod=444 qubership-apihub-service/resources ./resources
+COPY --chown=10001:0 --chmod=444 docs/api ./api
 
-# hadolint ignore=DL3018
-RUN apk --no-cache add curl ca-certificates
+USER 10001:10001
 
-COPY --from=builder /workspace/qubership-apihub-service/qubership-apihub-service ./qubership-apihub-service
-COPY qubership-apihub-service/static ./static
-COPY qubership-apihub-service/resources ./resources
-COPY docs/api ./api
-
-RUN chmod -R a+rwx /app
-
-USER 10001
-
-ENTRYPOINT ["./qubership-apihub-service"]
+CMD ["./qubership-apihub-service"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,9 @@ ENV GIT_HASH=$GIT_HASH
 WORKDIR /app/qubership-apihub-service
 
 COPY --chown=10001:0 --chmod=555 --from=builder /workspace/qubership-apihub-service/qubership-apihub-service ./qubership-apihub-service
-COPY --chown=10001:0 --chmod=444 qubership-apihub-service/static ./static
-COPY --chown=10001:0 --chmod=444 qubership-apihub-service/resources ./resources
-COPY --chown=10001:0 --chmod=444 docs/api ./api
+COPY --chown=10001:0 --chmod=555 qubership-apihub-service/static ./static
+COPY --chown=10001:0 --chmod=555 qubership-apihub-service/resources ./resources
+COPY --chown=10001:0 --chmod=555 docs/api ./api
 
 USER 10001:10001
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ WORKDIR /app/qubership-apihub-service
 USER root
 
 # hadolint ignore=DL3018
-RUN apk --no-cache add curl
+RUN apk --no-cache add curl ca-certificates
 
 COPY --from=builder /workspace/qubership-apihub-service/qubership-apihub-service ./qubership-apihub-service
 COPY qubership-apihub-service/static ./static

--- a/build_golang_binary.cmd
+++ b/build_golang_binary.cmd
@@ -1,8 +1,11 @@
-set GOSUMDB=off
 set CGO_ENABLED=0
 set GOOS=linux
+set GOARCH=amd64
 cd ./qubership-apihub-service
 go mod tidy
+if errorlevel 1 exit /b 1
 go mod download
+if errorlevel 1 exit /b 1
 go build .
+if errorlevel 1 exit /b 1
 cd ..

--- a/qubership-apihub-service/Service.go
+++ b/qubership-apihub-service/Service.go
@@ -78,6 +78,9 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	if err := utils.ValidateTLSAtStartup(); err != nil {
+		log.Fatalf("TLS configuration failed: %v", err)
+	}
 	basePath := systemInfoService.GetBasePath()
 
 	// Create router and server to expose live and ready endpoints during initialization
@@ -332,7 +335,10 @@ func main() {
 	apihubApiKeyController := controller.NewApihubApiKeyController(apihubApiKeyService, roleService)
 	cleanupController := controller.NewCleanupController(cleanupService)
 
-	playgroundProxyController := controller.NewPlaygroundProxyController(systemInfoService)
+	playgroundProxyController, err := controller.NewPlaygroundProxyController(systemInfoService)
+	if err != nil {
+		log.Fatalf("Failed to create PlaygroundProxyController: %v", err)
+	}
 	publishV2Controller := controller.NewPublishV2Controller(buildService, publishedService, buildResultService, roleService, systemInfoService)
 	exportController := controller.NewExportController(publishedService, portalService, roleService, excelService, versionService, monitoringService, exportService, packageService)
 

--- a/qubership-apihub-service/client/OpenAIClient.go
+++ b/qubership-apihub-service/client/OpenAIClient.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"net/http"
@@ -10,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Netcracker/qubership-apihub-backend/qubership-apihub-service/config"
+	"github.com/Netcracker/qubership-apihub-backend/qubership-apihub-service/utils"
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/option"
 	"github.com/openai/openai-go/v3/shared"
@@ -28,10 +28,12 @@ type OpenAILlmClient struct {
 }
 
 func NewOpenAILlmClient(cfg config.OpenAIConfig) (LlmClient, error) {
+	tlsConfig, err := utils.BuildSecureTLSConfig(nil)
+	if err != nil {
+		return nil, fmt.Errorf("build TLS config: %w", err)
+	}
 	transport := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true,
-		},
+		TLSClientConfig: tlsConfig,
 	}
 	httpClient := &http.Client{
 		Transport: transport,

--- a/qubership-apihub-service/controller/PlaygroundProxyController.go
+++ b/qubership-apihub-service/controller/PlaygroundProxyController.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"crypto/tls"
 	"io"
 	"net/http"
 	"net/url"
@@ -22,7 +21,7 @@ type ProxyController interface {
 
 func NewPlaygroundProxyController(systemInfoService service.SystemInfoService) ProxyController {
 	return &playgroundProxyControllerImpl{
-		tr:                http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
+		tr:                http.Transport{TLSClientConfig: utils.GetSecureTLSConfig()},
 		systemInfoService: systemInfoService}
 }
 

--- a/qubership-apihub-service/controller/PlaygroundProxyController.go
+++ b/qubership-apihub-service/controller/PlaygroundProxyController.go
@@ -19,10 +19,14 @@ type ProxyController interface {
 	Proxy(w http.ResponseWriter, req *http.Request)
 }
 
-func NewPlaygroundProxyController(systemInfoService service.SystemInfoService) ProxyController {
+func NewPlaygroundProxyController(systemInfoService service.SystemInfoService) (ProxyController, error) {
+	tlsConfig, err := utils.BuildSecureTLSConfig(nil)
+	if err != nil {
+		return nil, err
+	}
 	return &playgroundProxyControllerImpl{
-		tr:                http.Transport{TLSClientConfig: utils.GetSecureTLSConfig()},
-		systemInfoService: systemInfoService}
+		tr:                http.Transport{TLSClientConfig: tlsConfig},
+		systemInfoService: systemInfoService}, nil
 }
 
 type playgroundProxyControllerImpl struct {

--- a/qubership-apihub-service/security/idp/providers/IDPManager.go
+++ b/qubership-apihub-service/security/idp/providers/IDPManager.go
@@ -3,12 +3,12 @@ package providers
 import (
 	"context"
 	"crypto/rsa"
-	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
 	"fmt"
 	"github.com/Netcracker/qubership-apihub-backend/qubership-apihub-service/security/idp"
 	"github.com/Netcracker/qubership-apihub-backend/qubership-apihub-service/service"
+	"github.com/Netcracker/qubership-apihub-backend/qubership-apihub-service/utils"
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/crewjam/saml"
 	"github.com/crewjam/saml/samlsp"
@@ -177,7 +177,7 @@ func CreateSAMLInstance(idpId string, samlConfig *idp.SAMLConfiguration) (*samls
 		return nil, err
 	}
 
-	tr := http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
+	tr := http.Transport{TLSClientConfig: utils.GetSecureTLSConfig()}
 	cl := http.Client{Transport: &tr, Timeout: time.Second * 60}
 	idpMetadata, err := samlsp.FetchMetadata(context.Background(), &cl, *idpMetadataURL)
 

--- a/qubership-apihub-service/security/idp/providers/IDPManager.go
+++ b/qubership-apihub-service/security/idp/providers/IDPManager.go
@@ -3,6 +3,7 @@ package providers
 import (
 	"context"
 	"crypto/rsa"
+	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
 	"fmt"

--- a/qubership-apihub-service/security/idp/providers/IDPManager.go
+++ b/qubership-apihub-service/security/idp/providers/IDPManager.go
@@ -85,7 +85,10 @@ func (i *idpManagerImpl) createOIDCProvider(idpConfig idp.IDP, userService servi
 		return nil, fmt.Errorf("OIDC configuration is invalid")
 	}
 
-	ctx := context.Background()
+	// Create a secure HTTP client for OIDC discovery
+	httpClient := createSecureHTTPClient()
+	ctx := oidc.ClientContext(context.Background(), httpClient)
+
 	provider, err := oidc.NewProvider(ctx, idpConfig.OIDCConfiguration.ProviderURL)
 	if err != nil {
 		log.Errorf("Failed to create OIDC provider: %v", err)
@@ -177,9 +180,8 @@ func CreateSAMLInstance(idpId string, samlConfig *idp.SAMLConfiguration) (*samls
 		return nil, err
 	}
 
-	tr := http.Transport{TLSClientConfig: utils.GetSecureTLSConfig()}
-	cl := http.Client{Transport: &tr, Timeout: time.Second * 60}
-	idpMetadata, err := samlsp.FetchMetadata(context.Background(), &cl, *idpMetadataURL)
+	httpClient := createSecureHTTPClient()
+	idpMetadata, err := samlsp.FetchMetadata(context.Background(), httpClient, *idpMetadataURL)
 
 	if err != nil {
 		log.Errorf("idpMetadata error - %s", err)
@@ -217,4 +219,11 @@ func CreateSAMLInstance(idpId string, samlConfig *idp.SAMLConfiguration) (*samls
 	}
 	log.Infof("SAML instance initialized")
 	return samlSP, nil
+}
+
+// createSecureHTTPClient creates an HTTP client with secure TLS configuration
+// for use in OIDC provider discovery and SAML metadata fetching
+func createSecureHTTPClient() *http.Client {
+	tr := http.Transport{TLSClientConfig: utils.GetSecureTLSConfig()}
+	return &http.Client{Transport: &tr, Timeout: time.Second * 60}
 }

--- a/qubership-apihub-service/security/idp/providers/IDPManager.go
+++ b/qubership-apihub-service/security/idp/providers/IDPManager.go
@@ -86,7 +86,10 @@ func (i *idpManagerImpl) createOIDCProvider(idpConfig idp.IDP, userService servi
 	}
 
 	// Create a secure HTTP client for OIDC discovery
-	httpClient := createSecureHTTPClient()
+	httpClient, err := createSecureHTTPClient()
+	if err != nil {
+		return nil, fmt.Errorf("create secure HTTP client for OIDC discovery: %w", err)
+	}
 	ctx := oidc.ClientContext(context.Background(), httpClient)
 
 	provider, err := oidc.NewProvider(ctx, idpConfig.OIDCConfiguration.ProviderURL)
@@ -180,7 +183,10 @@ func CreateSAMLInstance(idpId string, samlConfig *idp.SAMLConfiguration) (*samls
 		return nil, err
 	}
 
-	httpClient := createSecureHTTPClient()
+	httpClient, err := createSecureHTTPClient()
+	if err != nil {
+		return nil, fmt.Errorf("create secure HTTP client for SAML metadata: %w", err)
+	}
 	idpMetadata, err := samlsp.FetchMetadata(context.Background(), httpClient, *idpMetadataURL)
 
 	if err != nil {
@@ -223,7 +229,11 @@ func CreateSAMLInstance(idpId string, samlConfig *idp.SAMLConfiguration) (*samls
 
 // createSecureHTTPClient creates an HTTP client with secure TLS configuration
 // for use in OIDC provider discovery and SAML metadata fetching
-func createSecureHTTPClient() *http.Client {
-	tr := http.Transport{TLSClientConfig: utils.GetSecureTLSConfig()}
-	return &http.Client{Transport: &tr, Timeout: time.Second * 60}
+func createSecureHTTPClient() (*http.Client, error) {
+	tlsConfig, err := utils.BuildSecureTLSConfig(nil)
+	if err != nil {
+		return nil, err
+	}
+	tr := http.Transport{TLSClientConfig: tlsConfig}
+	return &http.Client{Transport: &tr, Timeout: time.Second * 60}, nil
 }

--- a/qubership-apihub-service/security/idp/providers/OIDCProvider.go
+++ b/qubership-apihub-service/security/idp/providers/OIDCProvider.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/sha256"
-	"crypto/tls"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -409,7 +408,7 @@ func (o oidcProvider) downloadAvatar(ctx context.Context, avatarURL string, toke
 }
 
 func makeHttpClient() *http.Client {
-	tr := http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
+	tr := http.Transport{TLSClientConfig: utils.GetSecureTLSConfig()}
 	cl := http.Client{Transport: &tr, Timeout: time.Second * 60}
 	return &cl
 }

--- a/qubership-apihub-service/security/idp/providers/OIDCProvider.go
+++ b/qubership-apihub-service/security/idp/providers/OIDCProvider.go
@@ -366,7 +366,11 @@ func (o oidcProvider) downloadAvatar(ctx context.Context, avatarURL string, toke
 		return nil
 	}
 
-	client := makeHttpClient()
+	client, err := makeHttpClient()
+	if err != nil {
+		log.Warnf("Failed to create HTTP client for avatar download: %v", err)
+		return nil
+	}
 
 	req, err := http.NewRequest(http.MethodGet, avatarURL, nil)
 	if err != nil {
@@ -407,8 +411,12 @@ func (o oidcProvider) downloadAvatar(ctx context.Context, avatarURL string, toke
 	return avatarData
 }
 
-func makeHttpClient() *http.Client {
-	tr := http.Transport{TLSClientConfig: utils.GetSecureTLSConfig()}
+func makeHttpClient() (*http.Client, error) {
+	tlsConfig, err := utils.BuildSecureTLSConfig(nil)
+	if err != nil {
+		return nil, err
+	}
+	tr := http.Transport{TLSClientConfig: tlsConfig}
 	cl := http.Client{Transport: &tr, Timeout: time.Second * 60}
-	return &cl
+	return &cl, nil
 }

--- a/qubership-apihub-service/service/MinioStorageService.go
+++ b/qubership-apihub-service/service/MinioStorageService.go
@@ -203,26 +203,20 @@ func createMinioClient(creds *view.MinioStorageCreds) *minioClient {
 		client.error = err
 		return client
 	}
-	crt, err := os.CreateTemp("", "minio.cert")
-	if err != nil {
-		log.Warn(err.Error())
-		client.error = err
-		return client
-	}
-	decodeSamlCert, err := base64.StdEncoding.DecodeString(creds.Crt)
-	if err != nil {
-		log.Warn(err.Error())
-		client.error = err
-		return client
+
+	// Decode custom certificate if provided
+	var decodedCert []byte
+	if creds.Crt != "" {
+		decodedCert, err = base64.StdEncoding.DecodeString(creds.Crt)
+		if err != nil {
+			log.Warn(err.Error())
+			client.error = err
+			return client
+		}
 	}
 
-	_, err = crt.WriteString(string(decodeSamlCert))
-	rootCAs := mustGetSystemCertPool()
-	data, err := os.ReadFile(crt.Name())
-	if err == nil {
-		rootCAs.AppendCertsFromPEM(data)
-	}
-	tr.TLSClientConfig.RootCAs = rootCAs
+	// Use the centralized TLS configuration utility
+	tr.TLSClientConfig = utils.GetSecureTLSConfigWithCustomCerts(decodedCert)
 
 	minioClient, err := minio.New(creds.Endpoint, &minio.Options{
 		Creds:     credentials.NewStaticV4(creds.AccessKeyId, creds.SecretAccessKey, ""),
@@ -351,13 +345,6 @@ func bucketExists(ctx context.Context, minioClient *minio.Client, bucketName str
 		return false, err
 	}
 	return exists, nil
-}
-func mustGetSystemCertPool() *x509.CertPool {
-	pool, err := x509.SystemCertPool()
-	if err != nil {
-		return x509.NewCertPool()
-	}
-	return pool
 }
 
 func buildFileName(tableName, entityId string) string {

--- a/qubership-apihub-service/service/MinioStorageService.go
+++ b/qubership-apihub-service/service/MinioStorageService.go
@@ -215,8 +215,13 @@ func createMinioClient(creds *view.MinioStorageCreds) *minioClient {
 		}
 	}
 
-	// Use the centralized TLS configuration utility
-	tr.TLSClientConfig = utils.GetSecureTLSConfigWithCustomCerts(decodedCert)
+	tlsConfig, err := utils.BuildSecureTLSConfig(decodedCert)
+	if err != nil {
+		log.Warn(err.Error())
+		client.error = err
+		return client
+	}
+	tr.TLSClientConfig = tlsConfig
 
 	minioClient, err := minio.New(creds.Endpoint, &minio.Options{
 		Creds:     credentials.NewStaticV4(creds.AccessKeyId, creds.SecretAccessKey, ""),

--- a/qubership-apihub-service/service/MinioStorageService.go
+++ b/qubership-apihub-service/service/MinioStorageService.go
@@ -3,12 +3,10 @@ package service
 import (
 	"bytes"
 	"context"
-	"crypto/x509"
 	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 	"time"
 

--- a/qubership-apihub-service/utils/TLSUtils.go
+++ b/qubership-apihub-service/utils/TLSUtils.go
@@ -1,0 +1,149 @@
+// Copyright 2024-2025 NetCracker Technology Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"os"
+	"path/filepath"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// GetSecureTLSConfig returns a TLS configuration with proper certificate validation.
+// It uses the system certificate pool and optionally loads custom CA certificates
+// from paths specified in the CUSTOM_CA_CERTS_PATH environment variable.
+// Multiple paths can be separated by colons (:) on Unix or semicolons (;) on Windows.
+func GetSecureTLSConfig() *tls.Config {
+	rootCAs := getSystemCertPool()
+	loadCustomCACerts(rootCAs)
+
+	return &tls.Config{
+		RootCAs:    rootCAs,
+		MinVersion: tls.VersionTLS12, // Enforce TLS 1.2 minimum
+	}
+}
+
+// GetSecureTLSConfigWithCustomCerts returns a TLS configuration with custom CA certificates
+// added to the system certificate pool. This is useful when you need to trust specific
+// certificates in addition to the system trust store.
+func GetSecureTLSConfigWithCustomCerts(pemData []byte) *tls.Config {
+	rootCAs := getSystemCertPool()
+
+	if pemData != nil && len(pemData) > 0 {
+		if ok := rootCAs.AppendCertsFromPEM(pemData); !ok {
+			log.Warn("Failed to append custom certificate to root CA pool")
+		} else {
+			log.Debug("Successfully added custom certificate to root CA pool")
+		}
+	}
+
+	loadCustomCACerts(rootCAs)
+
+	return &tls.Config{
+		RootCAs:    rootCAs,
+		MinVersion: tls.VersionTLS12,
+	}
+}
+
+// getSystemCertPool retrieves the system certificate pool.
+// If the system pool cannot be loaded, it returns a new empty pool.
+func getSystemCertPool() *x509.CertPool {
+	pool, err := x509.SystemCertPool()
+	if err != nil {
+		log.Warnf("Failed to load system certificate pool, using empty pool: %v", err)
+		return x509.NewCertPool()
+	}
+	return pool
+}
+
+// loadCustomCACerts loads custom CA certificates from paths specified in
+// the CUSTOM_CA_CERTS_PATH environment variable and adds them to the provided cert pool.
+// Paths can be files or directories. Directories are scanned recursively for .crt and .pem files.
+func loadCustomCACerts(pool *x509.CertPool) {
+	customCAPath := os.Getenv("CUSTOM_CA_CERTS_PATH")
+	if customCAPath == "" {
+		return
+	}
+
+	// Support multiple paths separated by : (Unix) or ; (Windows)
+	separator := ":"
+	if os.PathSeparator == '\\' {
+		separator = ";"
+	}
+
+	paths := strings.Split(customCAPath, separator)
+	for _, path := range paths {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			continue
+		}
+
+		loadCertsFromPath(pool, path)
+	}
+}
+
+// loadCertsFromPath loads certificates from a file or directory path
+func loadCertsFromPath(pool *x509.CertPool, path string) {
+	info, err := os.Stat(path)
+	if err != nil {
+		log.Warnf("Failed to access custom CA certificate path %s: %v", path, err)
+		return
+	}
+
+	if info.IsDir() {
+		loadCertsFromDirectory(pool, path)
+	} else {
+		loadCertFromFile(pool, path)
+	}
+}
+
+// loadCertsFromDirectory recursively loads all .crt and .pem files from a directory
+func loadCertsFromDirectory(pool *x509.CertPool, dirPath string) {
+	err := filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !info.IsDir() {
+			ext := strings.ToLower(filepath.Ext(path))
+			if ext == ".crt" || ext == ".pem" {
+				loadCertFromFile(pool, path)
+			}
+		}
+		return nil
+	})
+
+	if err != nil {
+		log.Warnf("Failed to walk directory %s for certificates: %v", dirPath, err)
+	}
+}
+
+// loadCertFromFile loads a certificate from a file and adds it to the pool
+func loadCertFromFile(pool *x509.CertPool, filePath string) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		log.Warnf("Failed to read certificate file %s: %v", filePath, err)
+		return
+	}
+
+	if ok := pool.AppendCertsFromPEM(data); !ok {
+		log.Warnf("Failed to parse certificate from file %s", filePath)
+	} else {
+		log.Infof("Successfully loaded custom CA certificate from %s", filePath)
+	}
+}

--- a/qubership-apihub-service/utils/TLSUtils.go
+++ b/qubership-apihub-service/utils/TLSUtils.go
@@ -18,15 +18,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
 	"sync"
-
-	log "github.com/sirupsen/logrus"
 )
-
-const customCACertsPathEnv = "CUSTOM_CA_CERTS_PATH"
 
 var (
 	baseTLSOnce sync.Once
@@ -41,9 +34,11 @@ func ValidateTLSAtStartup() error {
 }
 
 // BuildSecureTLSConfig returns a TLS configuration with proper certificate validation.
-// It uses the system certificate pool, optional inline PEM data, and custom CA certificates
-// from paths specified in the CUSTOM_CA_CERTS_PATH environment variable.
-// Multiple paths can be separated by colons (:) on Unix or semicolons (;) on Windows.
+// It uses the system certificate pool and optional inline PEM data (for example MinIO s3Storage.crt).
+//
+// In container deployments based on ghcr.io/netcracker/qubership-core-base, custom CA certificates
+// are loaded into the system trust store by the base image entrypoint from /tmp/cert/ before the
+// application starts. Mount .crt, .cer, or .pem files there in Compose or Kubernetes.
 func BuildSecureTLSConfig(customPEM []byte) (*tls.Config, error) {
 	if len(customPEM) == 0 {
 		baseTLSOnce.Do(func() {
@@ -78,86 +73,5 @@ func buildRootCertPool(customPEM []byte) (*x509.CertPool, error) {
 			return nil, fmt.Errorf("parse custom PEM certificate")
 		}
 	}
-	if err := loadCustomCACertsFromEnv(pool); err != nil {
-		return nil, err
-	}
 	return pool, nil
-}
-
-func loadCustomCACertsFromEnv(pool *x509.CertPool) error {
-	customCAPath := os.Getenv(customCACertsPathEnv)
-	if customCAPath == "" {
-		return nil
-	}
-
-	separator := ":"
-	if os.PathSeparator == '\\' {
-		separator = ";"
-	}
-
-	paths := strings.Split(customCAPath, separator)
-	for _, path := range paths {
-		path = strings.TrimSpace(path)
-		if path == "" {
-			continue
-		}
-		if err := loadCertsFromPath(pool, path); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func loadCertsFromPath(pool *x509.CertPool, path string) error {
-	info, err := os.Stat(path)
-	if err != nil {
-		return fmt.Errorf("access custom CA certificate path %s: %w", path, err)
-	}
-
-	if info.IsDir() {
-		loaded, err := loadCertsFromDirectory(pool, path)
-		if err != nil {
-			return err
-		}
-		if !loaded {
-			return fmt.Errorf("no certificates found in custom CA directory %s", path)
-		}
-		return nil
-	}
-	return loadCertFromFile(pool, path)
-}
-
-func loadCertsFromDirectory(pool *x509.CertPool, dirPath string) (bool, error) {
-	loaded := false
-	err := filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if !info.IsDir() {
-			ext := strings.ToLower(filepath.Ext(path))
-			if ext == ".crt" || ext == ".pem" {
-				if err := loadCertFromFile(pool, path); err != nil {
-					return err
-				}
-				loaded = true
-			}
-		}
-		return nil
-	})
-	if err != nil {
-		return false, fmt.Errorf("walk directory %s for certificates: %w", dirPath, err)
-	}
-	return loaded, nil
-}
-
-func loadCertFromFile(pool *x509.CertPool, filePath string) error {
-	data, err := os.ReadFile(filePath)
-	if err != nil {
-		return fmt.Errorf("read certificate file %s: %w", filePath, err)
-	}
-	if ok := pool.AppendCertsFromPEM(data); !ok {
-		return fmt.Errorf("parse certificate from file %s", filePath)
-	}
-	log.Infof("Successfully loaded custom CA certificate from %s", filePath)
-	return nil
 }

--- a/qubership-apihub-service/utils/TLSUtils.go
+++ b/qubership-apihub-service/utils/TLSUtils.go
@@ -17,70 +17,79 @@ package utils
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	log "github.com/sirupsen/logrus"
 )
 
-// GetSecureTLSConfig returns a TLS configuration with proper certificate validation.
-// It uses the system certificate pool and optionally loads custom CA certificates
-// from paths specified in the CUSTOM_CA_CERTS_PATH environment variable.
-// Multiple paths can be separated by colons (:) on Unix or semicolons (;) on Windows.
-func GetSecureTLSConfig() *tls.Config {
-	rootCAs := getSystemCertPool()
-	loadCustomCACerts(rootCAs)
+const customCACertsPathEnv = "CUSTOM_CA_CERTS_PATH"
 
-	return &tls.Config{
-		RootCAs:    rootCAs,
-		MinVersion: tls.VersionTLS12, // Enforce TLS 1.2 minimum
-	}
+var (
+	baseTLSOnce sync.Once
+	baseTLSCfg  *tls.Config
+	baseTLSErr  error
+)
+
+// ValidateTLSAtStartup validates the default TLS configuration at process startup.
+func ValidateTLSAtStartup() error {
+	_, err := BuildSecureTLSConfig(nil)
+	return err
 }
 
-// GetSecureTLSConfigWithCustomCerts returns a TLS configuration with custom CA certificates
-// added to the system certificate pool. This is useful when you need to trust specific
-// certificates in addition to the system trust store.
-func GetSecureTLSConfigWithCustomCerts(pemData []byte) *tls.Config {
-	rootCAs := getSystemCertPool()
-
-	if pemData != nil && len(pemData) > 0 {
-		if ok := rootCAs.AppendCertsFromPEM(pemData); !ok {
-			log.Warn("Failed to append custom certificate to root CA pool")
-		} else {
-			log.Debug("Successfully added custom certificate to root CA pool")
+// BuildSecureTLSConfig returns a TLS configuration with proper certificate validation.
+// It uses the system certificate pool, optional inline PEM data, and custom CA certificates
+// from paths specified in the CUSTOM_CA_CERTS_PATH environment variable.
+// Multiple paths can be separated by colons (:) on Unix or semicolons (;) on Windows.
+func BuildSecureTLSConfig(customPEM []byte) (*tls.Config, error) {
+	if len(customPEM) == 0 {
+		baseTLSOnce.Do(func() {
+			baseTLSCfg, baseTLSErr = buildSecureTLSConfig(nil)
+		})
+		if baseTLSErr != nil {
+			return nil, baseTLSErr
 		}
+		return baseTLSCfg.Clone(), nil
 	}
+	return buildSecureTLSConfig(customPEM)
+}
 
-	loadCustomCACerts(rootCAs)
-
+func buildSecureTLSConfig(customPEM []byte) (*tls.Config, error) {
+	rootCAs, err := buildRootCertPool(customPEM)
+	if err != nil {
+		return nil, err
+	}
 	return &tls.Config{
 		RootCAs:    rootCAs,
 		MinVersion: tls.VersionTLS12,
-	}
+	}, nil
 }
 
-// getSystemCertPool retrieves the system certificate pool.
-// If the system pool cannot be loaded, it returns a new empty pool.
-func getSystemCertPool() *x509.CertPool {
+func buildRootCertPool(customPEM []byte) (*x509.CertPool, error) {
 	pool, err := x509.SystemCertPool()
 	if err != nil {
-		log.Warnf("Failed to load system certificate pool, using empty pool: %v", err)
-		return x509.NewCertPool()
+		return nil, fmt.Errorf("load system certificate pool: %w", err)
 	}
-	return pool
+	if len(customPEM) > 0 {
+		if ok := pool.AppendCertsFromPEM(customPEM); !ok {
+			return nil, fmt.Errorf("parse custom PEM certificate")
+		}
+	}
+	if err := loadCustomCACertsFromEnv(pool); err != nil {
+		return nil, err
+	}
+	return pool, nil
 }
 
-// loadCustomCACerts loads custom CA certificates from paths specified in
-// the CUSTOM_CA_CERTS_PATH environment variable and adds them to the provided cert pool.
-// Paths can be files or directories. Directories are scanned recursively for .crt and .pem files.
-func loadCustomCACerts(pool *x509.CertPool) {
-	customCAPath := os.Getenv("CUSTOM_CA_CERTS_PATH")
+func loadCustomCACertsFromEnv(pool *x509.CertPool) error {
+	customCAPath := os.Getenv(customCACertsPathEnv)
 	if customCAPath == "" {
-		return
+		return nil
 	}
 
-	// Support multiple paths separated by : (Unix) or ; (Windows)
 	separator := ":"
 	if os.PathSeparator == '\\' {
 		separator = ";"
@@ -92,58 +101,63 @@ func loadCustomCACerts(pool *x509.CertPool) {
 		if path == "" {
 			continue
 		}
-
-		loadCertsFromPath(pool, path)
+		if err := loadCertsFromPath(pool, path); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
-// loadCertsFromPath loads certificates from a file or directory path
-func loadCertsFromPath(pool *x509.CertPool, path string) {
+func loadCertsFromPath(pool *x509.CertPool, path string) error {
 	info, err := os.Stat(path)
 	if err != nil {
-		log.Warnf("Failed to access custom CA certificate path %s: %v", path, err)
-		return
+		return fmt.Errorf("access custom CA certificate path %s: %w", path, err)
 	}
 
 	if info.IsDir() {
-		loadCertsFromDirectory(pool, path)
-	} else {
-		loadCertFromFile(pool, path)
+		loaded, err := loadCertsFromDirectory(pool, path)
+		if err != nil {
+			return err
+		}
+		if !loaded {
+			return fmt.Errorf("no certificates found in custom CA directory %s", path)
+		}
+		return nil
 	}
+	return loadCertFromFile(pool, path)
 }
 
-// loadCertsFromDirectory recursively loads all .crt and .pem files from a directory
-func loadCertsFromDirectory(pool *x509.CertPool, dirPath string) {
+func loadCertsFromDirectory(pool *x509.CertPool, dirPath string) (bool, error) {
+	loaded := false
 	err := filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
-
 		if !info.IsDir() {
 			ext := strings.ToLower(filepath.Ext(path))
 			if ext == ".crt" || ext == ".pem" {
-				loadCertFromFile(pool, path)
+				if err := loadCertFromFile(pool, path); err != nil {
+					return err
+				}
+				loaded = true
 			}
 		}
 		return nil
 	})
-
 	if err != nil {
-		log.Warnf("Failed to walk directory %s for certificates: %v", dirPath, err)
+		return false, fmt.Errorf("walk directory %s for certificates: %w", dirPath, err)
 	}
+	return loaded, nil
 }
 
-// loadCertFromFile loads a certificate from a file and adds it to the pool
-func loadCertFromFile(pool *x509.CertPool, filePath string) {
+func loadCertFromFile(pool *x509.CertPool, filePath string) error {
 	data, err := os.ReadFile(filePath)
 	if err != nil {
-		log.Warnf("Failed to read certificate file %s: %v", filePath, err)
-		return
+		return fmt.Errorf("read certificate file %s: %w", filePath, err)
 	}
-
 	if ok := pool.AppendCertsFromPEM(data); !ok {
-		log.Warnf("Failed to parse certificate from file %s", filePath)
-	} else {
-		log.Infof("Successfully loaded custom CA certificate from %s", filePath)
+		return fmt.Errorf("parse certificate from file %s", filePath)
 	}
+	log.Infof("Successfully loaded custom CA certificate from %s", filePath)
+	return nil
 }


### PR DESCRIPTION
## Summary

- Supersedes #260 (contribution by @vlsi). Cherry-picked onto current `develop` and extended.
- Fixes #106: replaces `InsecureSkipVerify: true` with proper certificate validation via centralized `utils/TLSUtils.go`.
- **Fail-fast:** TLS certificate loading errors (system pool, MinIO PEM) propagate and abort startup instead of warn-and-continue.
- **OpenAI client:** AI Chat outbound HTTP uses the same secure TLS configuration.
- **Runtime image:** uses [`ghcr.io/netcracker/qubership-core-base:2.3.3`](https://github.com/Netcracker/qubership-core-base-images) instead of plain Alpine — reuses the platform certificate contract.

## Certificate contract (core-base)

Custom CA certificates are **not** loaded via application env vars. The base image entrypoint loads them before the app starts:

1. Mount `.crt`, `.cer`, or `.pem` files into **`/tmp/cert/`** (Compose volume or K8s Secret/ConfigMap mount).
2. Entrypoint runs `update-ca-certificates` → system trust store at `/etc/ssl/certs`.
3. Go HTTP clients use `x509.SystemCertPool()` and pick up those CAs automatically.

**MinIO/S3** remains separate: optional base64 PEM in `config.yaml` → `s3Storage.crt`.

### Compose example

```yaml
qubership-apihub-backend:
  volumes:
    - ./certs/company-ca.pem:/tmp/cert/company-ca.pem:ro
```

### Kubernetes example

```yaml
volumeMounts:
  - name: custom-ca
    mountPath: /tmp/cert
    readOnly: true
volumes:
  - name: custom-ca
    secret:
      secretName: apihub-custom-ca
```

Also supported by core-base: K8s service account CA at `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`.

## Commits

1. Implement secure TLS configuration for HTTP clients (from #260)
2. fix: use secure HTTP client for OIDC provider discovery (from #260)
3. fix: fail fast when TLS certificate loading fails
4. fix: use secure TLS for OpenAI HTTP client
5. fix: install ca-certificates in runtime image *(superseded by commit 6)*
6. refactor: use qubership-core-base image and /tmp/cert CA contract

### Related repositories (follow-up outside this repo)

- **Helm / deployment** ([qubership-apihub](https://github.com/Netcracker/qubership-apihub)): mount custom CA into `/tmp/cert/` on backend Deployment/Compose (not `CUSTOM_CA_CERTS_PATH`). Document in `configuration-reference.md`.

## Test plan

- [x] Backend starts in core-base image without custom certs (public HTTPS works).
- [ ] Corporate IdP / internal HTTPS works with CA mounted to `/tmp/cert/`.
- [x] OIDC login, SAML metadata fetch, Playground proxy HTTPS, MinIO with `s3Storage.crt`.
- [x] AI Chat outbound calls (when enabled).
- [x] Health probes (`/ready`, `/live`) still pass; entrypoint wraps CMD correctly.
- [x] Close #260 manually after merge.