### PR TITLE
feat: Expose ai.chat.enabled in system info

### DIFF
--- a/docs/api/APIHUB_API.yaml
+++ b/docs/api/APIHUB_API.yaml
@@ -10631,6 +10631,10 @@ components:
           description: Identifies if a full migration is currently in progress. Returns false when no migration or only a partial migration is running.
           type: boolean
           default: false
+        aiChatEnabled:
+          description: Mirrors the ai.chat.enabled kill-switch. When false, AI chat routes are not registered.
+          type: boolean
+          default: false
         featureFlags:
           description: Feature flags for the system
           type: object
@@ -13138,6 +13142,7 @@ components:
         backendVersion: master-20250522.080756-379-RELEASE
         productionMode: true
         migrationInProgress: false
+        aiChatEnabled: false
         externalLinks:
           - User guide|https://www.example.com/guide
           - Support team|https://www.example.com/support]

--- a/qubership-apihub-service/service/SystemInfoService.go
+++ b/qubership-apihub-service/service/SystemInfoService.go
@@ -150,6 +150,7 @@ func (g *systemInfoServiceImpl) GetSystemInfo() *view.SystemInfo {
 		ProductionMode: g.IsProductionMode(),
 		Notification:   g.getSystemNotification(),
 		ExternalLinks:  g.GetExternalLinks(),
+		AiChatEnabled:  g.GetAiChatConfig().Enabled,
 		FeatureFlags:   g.GetFeatureFlags(),
 	}
 }

--- a/qubership-apihub-service/view/SystemInfo.go
+++ b/qubership-apihub-service/view/SystemInfo.go
@@ -5,11 +5,12 @@ import (
 )
 
 type SystemInfo struct {
-	BackendVersion      string         `json:"backendVersion"`
-	ProductionMode      bool           `json:"productionMode"`
-	Notification        string         `json:"notification,omitempty"`
-	ExternalLinks       []string       `json:"externalLinks"`
-	MigrationInProgress bool           `json:"migrationInProgress"`
+	BackendVersion      string       `json:"backendVersion"`
+	ProductionMode      bool         `json:"productionMode"`
+	Notification        string       `json:"notification,omitempty"`
+	ExternalLinks       []string     `json:"externalLinks"`
+	MigrationInProgress bool         `json:"migrationInProgress"`
+	AiChatEnabled       bool         `json:"aiChatEnabled"`
 	FeatureFlags        FeatureFlags `json:"featureFlags"`
 }
 


### PR DESCRIPTION
## Summary
- Add top-level `aiChatEnabled` field to `GET /api/v1/system/info`, sourced from `ai.chat.enabled` config
- Document the field in OpenAPI (`APIHUB_API.yaml`)

## Test plan
- [x] Start backend with `ai.chat.enabled: false` and verify `GET /api/v1/system/info` returns `"aiChatEnabled": false`
- [x] Set `ai.chat.enabled: true` and verify response returns `"aiChatEnabled": true`
