### PR TITLE
chore(deps): update ghcr.io/netcracker/qubership-core-base docker tag to v2.3.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Note: this uses host platform for the build, and we ask go build to target the needed platform, so we do not spend time on qemu emulation when running "go build"
-FROM --platform=$BUILDPLATFORM docker.io/golang:1.26.1-alpine3.23 AS builder
+FROM --platform=$BUILDPLATFORM docker.io/golang:1.26.5-alpine3.23 AS builder
 ARG BUILDPLATFORM
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /workspace/qubership-apihub-service
 
 RUN GOSUMDB=off CGO_ENABLED=0 go mod tidy && go mod download && GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build .
 
-FROM ghcr.io/netcracker/qubership-core-base:2.3.3@sha256:1339716127a7d170ba307b89f3a933f5e09c447607c89e16bf8d5a379db4e1f6
+FROM ghcr.io/netcracker/qubership-core-base:2.3.7@sha256:b917b3a1731a2ae26b507d22565f030ec25ff8d28b75a80b8b08bbc946f4d73b
 
 ARG GIT_BRANCH=unknown
 ARG GIT_HASH=unknown
@@ -30,3 +30,4 @@ COPY --chown=10001:0 --chmod=555 docs/api ./api
 USER 10001:10001
 
 CMD ["./qubership-apihub-service"]
+

--- a/qubership-apihub-service/go.mod
+++ b/qubership-apihub-service/go.mod
@@ -1,6 +1,6 @@
 module github.com/Netcracker/qubership-apihub-backend/qubership-apihub-service
 
-go 1.26.1
+go 1.26.5
 
 require (
 	github.com/Netcracker/qubership-apihub-commons-go v0.0.1


### PR DESCRIPTION
## Summary
- Update runtime base image `ghcr.io/netcracker/qubership-core-base` from `2.3.3` to `2.3.7` (latest release)

## Test plan
- [ ] Confirm Dockerfile pin matches `2.3.7` digest
- [ ] CI image build succeeds
