### PR TITLE
feat(versions): support multi-status filter on package versions list (#760)

### DIFF
--- a/docs/api/APIHUB_API.yaml
+++ b/docs/api/APIHUB_API.yaml
@@ -2887,14 +2887,14 @@ paths:
             type: string
         - name: status
           in: query
-          description: Filter versions by status (start with match)
+          description: |
+            Filter versions by status. Comma-separated list of values: draft, release, archived.
+            When omitted or empty, versions of all statuses are returned.
+            Unknown values return 400 Bad Request.
           required: false
           schema:
             type: string
-            enum:
-              - draft
-              - release
-              - archived
+            example: "draft,release"
         - name: checkRevisions
           in: query
           description: |

--- a/qubership-apihub-service/controller/ControllerUtils.go
+++ b/qubership-apihub-service/controller/ControllerUtils.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Netcracker/qubership-apihub-backend/qubership-apihub-service/service"
 
 	"github.com/Netcracker/qubership-apihub-backend/qubership-apihub-service/exception"
+	"github.com/Netcracker/qubership-apihub-backend/qubership-apihub-service/view"
 	"github.com/gorilla/mux"
 )
 
@@ -129,6 +130,29 @@ func getListFromParam(r *http.Request, param string) ([]string, *exception.Custo
 	}
 
 	return strings.Split(listStr, ","), nil
+}
+
+func parseVersionStatusQueryParam(r *http.Request) ([]string, *exception.CustomError) {
+	statusParts, customError := getListFromParam(r, "status")
+	if customError != nil {
+		return nil, customError
+	}
+	if len(statusParts) == 0 {
+		return nil, nil
+	}
+	statuses := make([]string, 0, len(statusParts))
+	for _, part := range statusParts {
+		if _, err := view.ParseVersionStatus(part); err != nil {
+			return nil, &exception.CustomError{
+				Status:  http.StatusBadRequest,
+				Code:    exception.InvalidParameterValue,
+				Message: exception.InvalidParameterValueMsg,
+				Params:  map[string]interface{}{"param": "status", "value": part},
+			}
+		}
+		statuses = append(statuses, part)
+	}
+	return statuses, nil
 }
 
 func getLimitQueryParam(r *http.Request) (int, *exception.CustomError) {

--- a/qubership-apihub-service/controller/VersionController.go
+++ b/qubership-apihub-service/controller/VersionController.go
@@ -451,7 +451,11 @@ func (v versionControllerImpl) GetPackageVersionsList(w http.ResponseWriter, r *
 		})
 		return
 	}
-	status := r.URL.Query().Get("status")
+	statuses, customError := parseVersionStatusQueryParam(r)
+	if customError != nil {
+		utils.RespondWithCustomError(w, customError)
+		return
+	}
 
 	limit, customError := getLimitQueryParam(r)
 	if customError != nil {
@@ -502,7 +506,7 @@ func (v versionControllerImpl) GetPackageVersionsList(w http.ResponseWriter, r *
 
 	versionListReq := view.VersionListReq{
 		PackageId:      packageId,
-		Status:         status,
+		Statuses:       statuses,
 		Limit:          limit,
 		Page:           page,
 		TextFilter:     textFilter,
@@ -547,7 +551,11 @@ func (v versionControllerImpl) GetDeletedPackageVersionsList(w http.ResponseWrit
 		})
 		return
 	}
-	status := r.URL.Query().Get("status")
+	statuses, customError := parseVersionStatusQueryParam(r)
+	if customError != nil {
+		utils.RespondWithCustomError(w, customError)
+		return
+	}
 
 	limit, customError := getLimitQueryParam(r)
 	if customError != nil {
@@ -572,7 +580,7 @@ func (v versionControllerImpl) GetDeletedPackageVersionsList(w http.ResponseWrit
 
 	versionListReq := view.VersionListReq{
 		PackageId: packageId,
-		Status:    status,
+		Statuses:  statuses,
 		Limit:     limit,
 		Page:      page,
 	}

--- a/qubership-apihub-service/entity/PublishedEntities.go
+++ b/qubership-apihub-service/entity/PublishedEntities.go
@@ -81,9 +81,9 @@ type PublishedVersionEntity struct {
 }
 
 type PublishedVersionSearchQueryEntity struct {
-	PackageId  string `pg:"package_id, type:varchar, use_zero"`
-	Status     string `pg:"status, type:varchar, use_zero"`
-	Label      string `pg:"label, type:varchar, use_zero"`
+	PackageId  string   `pg:"package_id, type:varchar, use_zero"`
+	Statuses   []string `pg:"statuses, type:varchar[], use_zero"`
+	Label      string   `pg:"label, type:varchar, use_zero"`
 	TextFilter string `pg:"text_filter, type:varchar, use_zero"`
 	SortBy     string `pg:"sort_by, type:varchar, use_zero"`
 	SortOrder  string `pg:"sort_order, type:varchar, use_zero"`

--- a/qubership-apihub-service/repository/PublishedRepositoryPG.go
+++ b/qubership-apihub-service/repository/PublishedRepositoryPG.go
@@ -2310,8 +2310,8 @@ func (p publishedRepositoryImpl) GetReadonlyPackageVersionsWithLimit(searchQuery
 	if searchQuery.TextFilter != "" {
 		searchQuery.TextFilter = "%" + utils.LikeEscaped(searchQuery.TextFilter) + "%"
 	}
-	if searchQuery.Status != "" {
-		searchQuery.Status = "%" + utils.LikeEscaped(searchQuery.Status) + "%"
+	if searchQuery.Statuses == nil {
+		searchQuery.Statuses = make([]string, 0)
 	}
 	if searchQuery.SortBy == "" {
 		searchQuery.SortBy = entity.GetVersionSortByPG(view.VersionSortByCreatedAt)
@@ -2337,7 +2337,7 @@ func (p publishedRepositoryImpl) GetReadonlyPackageVersionsWithLimit(searchQuery
 			where pv.deleted_at is null
 			and (pv.package_id = ?package_id)
 			and (?text_filter = '' or pv.version ilike ?text_filter OR EXISTS(SELECT 1 FROM unnest(pv.labels) as label WHERE label ILIKE ?text_filter))
-			and (?status = '' or pv.status ilike ?status)
+			and (?statuses = '{}' or pv.status = ANY(?statuses))
 			and (?label = '' or ?label = any(pv.labels))
 			order by pv.published_at desc
 			`
@@ -2414,7 +2414,7 @@ func (p publishedRepositoryImpl) GetReadonlyPackageVersionsWithLimit(searchQuery
 			left join user_data usr on usr.user_id = pv.created_by
 			left join apihub_api_keys apikey on apikey.id = pv.created_by
 			where (?text_filter = '' or pv.version ilike ?text_filter OR EXISTS(SELECT 1 FROM unnest(pv.labels) as label WHERE label ILIKE ?text_filter))
-			and (?status = '' or pv.status ilike ?status)
+			and (?statuses = '{}' or pv.status = ANY(?statuses))
 			and (?label = '' or ?label = any(pv.labels))
 			and pv.deleted_at is %s null
 			order by pv.%s %s

--- a/qubership-apihub-service/service/MCPService.go
+++ b/qubership-apihub-service/service/MCPService.go
@@ -225,7 +225,7 @@ func (m mcpService) GetPackagesList(ctx context.Context, workspaceId string) ([]
 		packageInfo := &packagesMCP.Packages[i]
 		versionsReq := view.VersionListReq{
 			PackageId: packageInfo.Id,
-			Status:    "release",
+			Statuses:  []string{string(view.Release)},
 			Limit:     100,
 			Page:      0,
 			SortBy:    view.VersionSortByVersion,

--- a/qubership-apihub-service/service/VersionService.go
+++ b/qubership-apihub-service/service/VersionService.go
@@ -659,7 +659,7 @@ func (v versionServiceImpl) GetPackageVersionsView(req view.VersionListReq, show
 
 	searchQueryReq := entity.PublishedVersionSearchQueryEntity{
 		PackageId:  req.PackageId,
-		Status:     req.Status,
+		Statuses:   req.Statuses,
 		Label:      req.Label,
 		TextFilter: req.TextFilter,
 		SortBy:     versionSortByPG,

--- a/qubership-apihub-service/view/Version.go
+++ b/qubership-apihub-service/view/Version.go
@@ -118,7 +118,7 @@ type VersionPatchRequest struct {
 
 type VersionListReq struct {
 	PackageId      string
-	Status         string
+	Statuses       []string
 	Limit          int
 	Page           int
 	TextFilter     string

--- a/qubership-apihub-service/view/VersionStatus.go
+++ b/qubership-apihub-service/view/VersionStatus.go
@@ -34,3 +34,19 @@ func ParseVersionStatus(s string) (VersionStatus, error) {
 	}
 	return "", fmt.Errorf("unknown version status: %v", s)
 }
+
+// ParseVersionStatuses validates each comma-separated status value from a query parameter list.
+// An empty list means no status filter (all statuses).
+func ParseVersionStatuses(parts []string) ([]string, error) {
+	if len(parts) == 0 {
+		return nil, nil
+	}
+	statuses := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if _, err := ParseVersionStatus(part); err != nil {
+			return nil, err
+		}
+		statuses = append(statuses, part)
+	}
+	return statuses, nil
+}

--- a/qubership-apihub-service/view/VersionStatus_test.go
+++ b/qubership-apihub-service/view/VersionStatus_test.go
@@ -1,0 +1,33 @@
+package view
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseVersionStatuses(t *testing.T) {
+	t.Run("empty list returns nil", func(t *testing.T) {
+		statuses, err := ParseVersionStatuses(nil)
+		require.NoError(t, err)
+		assert.Nil(t, statuses)
+	})
+
+	t.Run("single valid status", func(t *testing.T) {
+		statuses, err := ParseVersionStatuses([]string{"release"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"release"}, statuses)
+	})
+
+	t.Run("multiple valid statuses", func(t *testing.T) {
+		statuses, err := ParseVersionStatuses([]string{"draft", "release"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"draft", "release"}, statuses)
+	})
+
+	t.Run("unknown status returns error", func(t *testing.T) {
+		_, err := ParseVersionStatuses([]string{"draft", "invalid"})
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
## Summary
- Allow comma-separated `status` values on `GET /api/v3/packages/{packageId}/versions` (e.g. `?status=draft,release`).
- Validate each status; unknown values return 400 Bad Request.
- Update OpenAPI and repository filter to use exact status match via `ANY(statuses)`.

Closes Netcracker/qubership-apihub#760

## Test plan
- [x] `go test ./view/...` — ParseVersionStatuses unit tests
- [x] `go build ./...` — compiles
- [ ] Manual: `?status=release` unchanged behaviour
- [ ] Manual: `?status=draft,release` returns union with correct pagination
- [ ] Manual: `?status=invalid` returns 400
- [ ] E2E follow-up PR in qubership-apihub-postman-collections

Made with [Cursor](https://cursor.com)